### PR TITLE
Fixes to debian packaging for YADIFA

### DIFF
--- a/debian/apparmor/usr.sbin.yadifad
+++ b/debian/apparmor/usr.sbin.yadifad
@@ -1,0 +1,28 @@
+# vim:syntax=apparmor
+# AppArmor policy for yadifad
+
+# No template variables specified
+
+#include <tunables/global>
+/usr/sbin/yadifad {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/consoles>
+
+  capability dac_override,
+  capability chown,
+  capability setuid,
+  capability setgid,
+  capability kill,
+
+  /etc/yadifa/** r,
+
+  /{,var/}run/yadifa/* rwk,
+
+  /var/lib/yadifa/** rw,
+  /var/log/yadifa/** rw,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.sbin.yadifad>
+
+}

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Markus Schade <markus.schade@gmail.com>
 Build-Depends:
- autotools-dev,
+ dh-autoreconf,
  debhelper (>= 9),
  dh-systemd,
  dpkg-dev (>= 1.16.1~),

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends:
  debhelper (>= 9),
  dh-systemd,
  dpkg-dev (>= 1.16.1~),
- libssl-dev
+ libssl-dev,
+ dh-apparmor
 Standards-Version: 3.9.6
 Homepage: http://www.yadifa.eu
 Vcs-Git: git://github.com/asciiprod/yadifa.git
@@ -22,6 +23,8 @@ Depends:
  netbase,
  ${misc:Depends},
  ${shlibs:Depends}
+Suggests:
+ apparmor
 Description: Internet Domain Name Server
  ${Description}
  .

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@
 export DH_OPTIONS
 
 %:
-	dh $@  --with autotools-dev
+	dh $@  --with autoreconf
 
 override_dh_clean:
 	dh_clean

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,10 @@ override_dh_clean:
 override_dh_auto_configure:
 	dh_auto_configure -- --enable-rrl --enable-nsid --with-tools --enable-ctrl
 
+override_dh_install:
+	dh_install
+	dh_apparmor --profile-name=usr.sbin.yadifad -pyadifa
+
 override_dh_installinit:
 	dh_installinit -a --no-start
 

--- a/debian/yadifa.install
+++ b/debian/yadifa.install
@@ -1,4 +1,5 @@
 /debian/yadifad.conf /etc/yadifa/
+/debian/apparmor/usr.sbin.yadifad /etc/apparmor.d/
 /var/zones/masters/0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.zone /var/lib/yadifa/masters/
 /var/zones/masters/0.0.127.in-addr.arpa.zone /var/lib/yadifa/masters/
 /var/zones/masters/localhost.zone /var/lib/yadifa/masters/

--- a/debian/yadifa.postinst
+++ b/debian/yadifa.postinst
@@ -51,7 +51,7 @@ case "$1" in
 	dpkg-statoverride --list /var/lib/yadifa/slaves > /dev/null || dpkg-statoverride --update --add yadifa yadifa 0755 /var/lib/yadifa/slaves
 	dpkg-statoverride --list /var/lib/yadifa/xfr > /dev/null || dpkg-statoverride --update --add yadifa yadifa 0755 /var/lib/yadifa/xfr
 	dpkg-statoverride --list /var/log/yadifa > /dev/null || dpkg-statoverride --update --add yadifa yadifa 0755 /var/log/yadifa
-	dpkg-statoverride --list /etc/yadifa/yadifad.conf > /dev/null || dpkg-statoverride --update --add yadifa yadifa 0640 /etc/yadifa/yadifad.conf
+	dpkg-statoverride --list /etc/yadifa/yadifad.conf > /dev/null || dpkg-statoverride --update --add root yadifa 0640 /etc/yadifa/yadifad.conf
 
 	if pidof /usr/sbin/yadifad >/dev/null 2>&1; then
 	    invoke-rc.d yadifa restart

--- a/debian/yadifa.service
+++ b/debian/yadifa.service
@@ -4,7 +4,7 @@ Documentation=man:yadifa(8)
 After=network.target
 
 [Service]
-ExecStart=/usr/sbin/yadifad -c /etc/yadifa/yadifad.conf
+ExecStart=/usr/sbin/yadifad -c /etc/yadifa/yadifad.conf --nodaemon
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/yadifa.tmpfile
+++ b/debian/yadifa.tmpfile
@@ -1,1 +1,1 @@
-d /run/yadfia 0775 root yadifa - -
+d /run/yadifa 0775 root yadifa - -

--- a/debian/yadifad.conf
+++ b/debian/yadifad.conf
@@ -11,7 +11,10 @@
 
         # The path of the chroot dir, all further paths are relative to this, if chroot is set to on
         chroot_path                 "/var/lib/yadifa"
- 
+
+        # Support client commands prototype from localhost
+        allow-control               localhost
+
         # The path where all the log files will be written
         logpath                     "/var/log/yadifa"
 
@@ -150,11 +153,12 @@
 # Access Control List definitions
 #
 
-#<acl>
+<acl>
 #        transferer  key master-slave
 #        admins      192.0.2.0/24, 2001:db8::74
 #        master      192.0.2.53
-#</acl>
+        localhost    127.0.0.0/8, ::1
+</acl>
 
 #
 # Master domain zone config

--- a/debian/yadifad.conf
+++ b/debian/yadifad.conf
@@ -124,13 +124,13 @@
 
 <loggers>
 #       bundle          debuglevel                          channels
-        database        *                                   database,all
-        dnssec          *                                   dnssec,all
+        database        EMERG,ALERT,CRIT,ERR,WARNING,NOTICE database,all
+        dnssec          EMERG,ALERT,CRIT,ERR,WARNING,NOTICE dnssec,all
         server          *                                   server,all
         statistics      *                                   statistics
-        system          *                                   system,all
-        zone            *                                   zone,all
-        queries         *                                   queries
+        system          EMERG,ALERT,CRIT,ERR,WARNING,NOTICE system,all
+        zone            EMERG,ALERT,CRIT,ERR,WARNING,NOTICE zone,all
+#        queries         *                                   queries
 </loggers>
 
 #

--- a/debian/yadifad.conf
+++ b/debian/yadifad.conf
@@ -31,7 +31,7 @@
         xfrpath                     "/var/lib/yadifa/xfr"
 
         # The version returned by a query to version.yadifa. CH TXT
-        version                     "2.0.5"
+#        version                     "2.0.5"
 
         # Set the maximum UDP packet size.  Cannot be less than 512.  Cannot be
         # more than 65535.  Typical choice is 4096.

--- a/debian/yadifad.conf
+++ b/debian/yadifad.conf
@@ -51,7 +51,7 @@
         port                        53
 
         # The interfaces to listen to.
-        listen                      0.0.0.0
+        listen                      127.0.0.1
 
         # Enable the collection and logging of statistics
         statistics                  on

--- a/open-build-service/yadifa.dsc
+++ b/open-build-service/yadifa.dsc
@@ -1,0 +1,12 @@
+Format: 1.0
+Source: yadifa
+Binary: yadifa, libyadifa-dev
+Architecture: any
+Version: 
+Maintainer: Markus Schade <markus.schade@gmail.com>
+Build-Depends: autotools-dev, debhelper (>= 9), dh-systemd, dpkg-dev (>= 1.16.1~), libssl-dev
+Package-List:
+ libyadifa-dev deb libdevel optional arch=any
+ yadifa deb net optional arch=any
+Files:
+ 00000000000000000000000000000000 0 yadifa.tar.gz


### PR DESCRIPTION
I think you'll want most of these.

No permitting a running process to rewrite it's configuration is better from a security perspective.

The apparmor profile hasn't been full tested but I will expand it as I find problems. If it's problematic you can stop it enforcing with aa-complain /etc/apparmor.d/usr.sbin.yadifad

Tested on a Debian Jessie system running systemd.
