### PR TITLE
Fix build on POWER due to a known issue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+yadifa (2.2.2-1.1) UNRELEASED; urgency=medium
+
+  * Avoid compiling with O3 on ppc64el due to a known bug
+
+ -- Breno Leitao <breno.leitao@gmail.com>  Mon, 28 Nov 2016 15:12:29 -0500
+
 yadifa (2.2.2-1) unstable; urgency=medium
 
   * New upstream version 2.2.2 (Closes: #828612)

--- a/debian/patches/fix-ppc64el_ftbfs.patch
+++ b/debian/patches/fix-ppc64el_ftbfs.patch
@@ -1,0 +1,25 @@
+--- /home/breno/yadifa-2.2.2/m4/eurid.m4	2016-11-08 05:56:43.140600104 -0500
++++ /home/breno/source/yadifa-2.2.2/m4/eurid.m4	2016-11-28 15:27:26.095324622 -0500
+@@ -298,6 +298,9 @@ case "$(uname -m)" in
+ 		CPU_UNKNOWN=0
+ 		cpu_intel_compatible=1
+ 		;;
++	ppc64le)
++		cpu_power_compatible=1
++		;;
+ 	*)
+ 		;;
+ esac
+@@ -626,6 +629,12 @@ then
+ 		fi
+ 	fi
+ 
++	dnl Move to O2 due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78543
++	if [[ $cpu_power_compatible -eq 1 ]]
++	then
++	    CCOPTIMISATIONFLAGS=-O2
++	fi
++	
+     AM_CONDITIONAL([USES_ICC], [false])
+     AM_CONDITIONAL([USES_GCC], [true])
+     AM_CONDITIONAL([USES_CLANG], [false])

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ fix-yadifad.conf.patch
 fix-yadifad-spelling.patch
 fix-yadifarc-manpage.patch
 do-not-use-or-define-the-compile-date.patch
+fix-ppc64el_ftbfs.patch


### PR DESCRIPTION
Currently YADIFA failes to build on POWER due to a known issue. Avoid O3
on POWER builds at this moment.

GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78543